### PR TITLE
Build stylish cost calculator wordpress plugin

### DIFF
--- a/ultimate-cost-calculator/admin/index.php
+++ b/ultimate-cost-calculator/admin/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/ultimate-cost-calculator/builder/index.php
+++ b/ultimate-cost-calculator/builder/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/ultimate-cost-calculator/includes/class-ucc-cpt.php
+++ b/ultimate-cost-calculator/includes/class-ucc-cpt.php
@@ -1,0 +1,35 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+class UCC_CPT {
+    public static function register() {
+        $labels = [
+            'name'               => __( 'Calculators', 'ultimate-cost-calculator' ),
+            'singular_name'      => __( 'Calculator', 'ultimate-cost-calculator' ),
+            'add_new'            => __( 'Add New', 'ultimate-cost-calculator' ),
+            'add_new_item'       => __( 'Add New Calculator', 'ultimate-cost-calculator' ),
+            'edit_item'          => __( 'Edit Calculator', 'ultimate-cost-calculator' ),
+            'new_item'           => __( 'New Calculator', 'ultimate-cost-calculator' ),
+            'all_items'          => __( 'All Calculators', 'ultimate-cost-calculator' ),
+            'view_item'          => __( 'View Calculator', 'ultimate-cost-calculator' ),
+            'search_items'       => __( 'Search Calculators', 'ultimate-cost-calculator' ),
+            'not_found'          => __( 'No calculators found', 'ultimate-cost-calculator' ),
+            'not_found_in_trash' => __( 'No calculators found in Trash', 'ultimate-cost-calculator' ),
+            'menu_name'          => __( 'Cost Calculators', 'ultimate-cost-calculator' ),
+        ];
+
+        $args = [
+            'labels'             => $labels,
+            'public'             => false,
+            'show_ui'            => true,
+            'show_in_menu'       => true,
+            'menu_icon'          => 'dashicons-calculator',
+            'supports'           => [ 'title', 'editor' ],
+            'has_archive'        => false,
+            'show_in_rest'       => true,
+            'capability_type'    => 'post',
+        ];
+
+        register_post_type( 'calculator', $args );
+    }
+}

--- a/ultimate-cost-calculator/includes/class-ucc-plugin.php
+++ b/ultimate-cost-calculator/includes/class-ucc-plugin.php
@@ -1,0 +1,41 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+class UCC_Plugin {
+    private static $instance = null;
+
+    public static function instance() {
+        if ( self::$instance === null ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    private function __construct() {
+        $this->includes();
+        $this->init_hooks();
+    }
+
+    private function includes() {
+        require_once UCC_PLUGIN_DIR . 'includes/class-ucc-cpt.php';
+        // Add more includes as needed
+    }
+
+    private function init_hooks() {
+        add_action( 'init', [ $this, 'register_post_types' ] );
+        // Add more hooks as needed
+    }
+
+    public function register_post_types() {
+        UCC_CPT::register();
+    }
+
+    public static function activate() {
+        self::instance()->register_post_types();
+        flush_rewrite_rules();
+    }
+
+    public static function deactivate() {
+        flush_rewrite_rules();
+    }
+}

--- a/ultimate-cost-calculator/includes/index.php
+++ b/ultimate-cost-calculator/includes/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/ultimate-cost-calculator/languages/index.php
+++ b/ultimate-cost-calculator/languages/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/ultimate-cost-calculator/public/index.php
+++ b/ultimate-cost-calculator/public/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/ultimate-cost-calculator/readme.txt
+++ b/ultimate-cost-calculator/readme.txt
@@ -1,0 +1,25 @@
+=== Ultimate Cost Calculator ===
+Contributors: yourname
+Tags: cost calculator, drag and drop, pricing, quote, builder
+Requires at least: 5.6
+Tested up to: 6.5
+Stable tag: 1.0.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+== Description ==
+Ultimate Cost Calculator is a powerful, stylish, and fully customizable cost calculator plugin for WordPress. Build beautiful calculators with a drag-and-drop builder, real-time pricing, and advanced features. Compatible with Elementor, Gutenberg, and more.
+
+== Installation ==
+1. Upload the plugin files to the `/wp-content/plugins/ultimate-cost-calculator` directory, or install the plugin through the WordPress plugins screen directly.
+2. Activate the plugin through the 'Plugins' screen in WordPress.
+3. Use the 'Cost Calculators' menu to create and manage calculators.
+
+== Usage ==
+- Create a new calculator from the admin menu.
+- Use the drag-and-drop builder to add fields and configure pricing.
+- Embed calculators using the [ultimate_cost_calculator id="123"] shortcode.
+
+== Changelog ==
+= 1.0.0 =
+* Initial release.

--- a/ultimate-cost-calculator/ultimate-cost-calculator.php
+++ b/ultimate-cost-calculator/ultimate-cost-calculator.php
@@ -1,0 +1,45 @@
+<?php
+/*
+Plugin Name: Ultimate Cost Calculator
+Description: Drag-and-drop cost calculator with stylish UI and advanced features. Compatible with Elementor, Gutenberg, and more.
+Version: 1.0.0
+Author: Your Name
+Text Domain: ultimate-cost-calculator
+Domain Path: /languages
+*/
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+// Define plugin constants
+define( 'UCC_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'UCC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+define( 'UCC_VERSION', '1.0.0' );
+
+defined( 'UCC_PLUGIN_BASENAME' ) || define( 'UCC_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+
+// Autoloader for classes
+spl_autoload_register( function ( $class ) {
+    if ( strpos( $class, 'UCC_' ) === 0 ) {
+        $file = UCC_PLUGIN_DIR . 'includes/class-' . strtolower( str_replace( '_', '-', $class ) ) . '.php';
+        if ( file_exists( $file ) ) {
+            require_once $file;
+        }
+    }
+});
+
+// Load text domain for translations
+add_action( 'plugins_loaded', function() {
+    load_plugin_textdomain( 'ultimate-cost-calculator', false, dirname( UCC_PLUGIN_BASENAME ) . '/languages' );
+});
+
+// Plugin activation/deactivation hooks
+register_activation_hook( __FILE__, [ 'UCC_Plugin', 'activate' ] );
+register_deactivation_hook( __FILE__, [ 'UCC_Plugin', 'deactivate' ] );
+
+// Initialize the plugin
+add_action( 'plugins_loaded', function() {
+    require_once UCC_PLUGIN_DIR . 'includes/class-ucc-plugin.php';
+    UCC_Plugin::instance();
+});


### PR DESCRIPTION
Scaffold the initial 'Ultimate Cost Calculator' plugin structure and register the `calculator` Custom Post Type.

---

[Open in Web](https://cursor.com/agents?id=bc-4818c7cb-14d2-4fa9-ba84-405ebd625118) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-4818c7cb-14d2-4fa9-ba84-405ebd625118) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)